### PR TITLE
Fixed bug after changes in wetransfer

### DIFF
--- a/snippet.php
+++ b/snippet.php
@@ -41,7 +41,8 @@ function downloadWeTransfer($url)
 	{
 		$action  = $response['formdata']['action'];
 		$postdata = http_build_query($response['fields']);
-		$filename = urldecode($response['fields']['filename']);
+		$pieces = explode("/", $action);
+		$filename = urldecode(array_pop($pieces));
 
 		$local_handle = fopen($filename, 'w+b');
 		$ch = curl_init();


### PR DESCRIPTION
Wetransfer no longer gives a filename, so now I detect the filename from the "action"